### PR TITLE
Fix(gatsby-source-drupal): checking to see if array is empty

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -140,16 +140,19 @@ exports.sourceNodes = async (
   downloadingFilesActivity.start()
 
   // Download all files (await for each pool to complete to fix concurrency issues)
-  await asyncPool(
-    concurrentFileRequests,
-    [...nodes.values()].filter(isFileNode),
-    async node => {
-      await downloadFile(
-        { node, store, cache, createNode, createNodeId },
-        pluginOptions
-      )
-    }
-  )
+  const fileNodes = [...nodes.values()].filter(isFileNode)
+  if(fileNodes) {
+    await asyncPool(
+      concurrentFileRequests,
+      fileNodes,
+      async node => {
+        await downloadFile(
+          { node, store, cache, createNode, createNodeId },
+          pluginOptions
+        )
+      }
+    )
+  }
 
   downloadingFilesActivity.end()
 

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -141,7 +141,7 @@ exports.sourceNodes = async (
 
   // Download all files (await for each pool to complete to fix concurrency issues)
   const fileNodes = [...nodes.values()].filter(isFileNode)
-  if(fileNodes) {
+  if(fileNodes.length) {
     await asyncPool(
       concurrentFileRequests,
       fileNodes,


### PR DESCRIPTION
I wasn't really sure how to replicate this issue, but I believe this will fix it!

## Description

Checking to see if there are any images in the array before running asyncPool. This avoids errors when the array contains no images.

## Related Issues

Fixes
https://github.com/gatsbyjs/gatsby/issues/15761